### PR TITLE
On stat rollover, use new value rather than 0

### DIFF
--- a/spec/insights_event_spec.cr
+++ b/spec/insights_event_spec.cr
@@ -116,11 +116,11 @@ describe Envoymon::InsightsEvent do
       expect(result.data["10.4.18.35:24699"]["rq_error"]).to eq(1_i64)
     end
 
-    it "does not return negative numbers" do
-      new_event.data["10.4.19.228:30848"]["cx_total"] = 0_i64
+    it "returns the new value rather than a negative" do
+      new_event.data["10.4.19.228:30848"]["cx_total"] = 1_i64
       result = base_event.subtract(new_event)
 
-      expect(result.data["10.4.19.228:30848"]["cx_total"]).to eq(0_i64)
+      expect(result.data["10.4.19.228:30848"]["cx_total"]).to eq(1_i64)
     end
 
     it "builds the right events in subtract()" do

--- a/src/envoymon/insights_event.cr
+++ b/src/envoymon/insights_event.cr
@@ -61,7 +61,10 @@ module Envoymon
           next unless @data.has_key?(host)
           result[host] = Hash(String, Int64).new unless result.has_key?(host)
           result[host][stat_name] = values[stat_name] - @data[host][stat_name]
-          result[host][stat_name] = 0_i64 if (result[host][stat_name] < 0_i64)
+          # If we rolled over the stat such that we'd end up with a
+          # negative number, the implication is that the proxy restarted
+          # during this minute and we can just use the new value.
+          result[host][stat_name] = values[stat_name] if (result[host][stat_name] < 0_i64)
         end
       end
 


### PR DESCRIPTION
When Envoy is deployed and envoymon has been running, we could end up with negative values when subtracting the counters. This was previously handled by setting all negative values to 0. A better solution should be to set them to the new value, because that value will by requirement have just been gathered in the current minute and is going to be more accurate than 0.