### PR TITLE
Fix errors when calling to_json on empty data

### DIFF
--- a/spec/insights_event_spec.cr
+++ b/spec/insights_event_spec.cr
@@ -83,7 +83,18 @@ describe Envoymon::InsightsEvent do
       })
   end
 
-  describe "Passes through initialization settings to JSON" do
+  describe "When generating JSON" do
+    it "doesn't crash when event is malformed" do
+      evt = Envoymon::InsightsEvent.new(
+        new_event.timestamp, # just re-use any valid timestamp
+        "borked",
+        "bork world",
+        Hash(String, Hash(String, Int64)).new
+      )
+
+      expect { evt.to_json }.not_to raise_error
+    end
+
     it "preserves the environment and service" do
       json = new_event.to_json
 

--- a/src/envoymon/insights_event.cr
+++ b/src/envoymon/insights_event.cr
@@ -17,8 +17,10 @@ module Envoymon
     ); end
 
     def to_json
-      host_port = @data.keys.first
-      values = @data[host_port]
+      return "{}" if @data.empty?
+
+      service_port = @data.keys.first
+      values = @data[service_port]
 
       JSON.build do |json|
         json.object do
@@ -26,7 +28,7 @@ module Envoymon
           json.field "eventType", "EnvoyStats"
           json.field "environment", @environment
           json.field "service", @name
-          json.field "sourceIpHost", host_port
+          json.field "sourceIpHost", service_port
           json.field "cx_active", values["cx_active"]
           json.field "cx_connect_fail", values["cx_connect_fail"]
           json.field "cx_total", values["cx_total"]


### PR DESCRIPTION
This will fix occasional issues where data was empty and `to_json` was called on the event. Found these in our logs in a few places:

```
Index out of bounds (IndexError)
  from /usr/lib/crystal/src/json/builder.cr:33:13 in '__crystal_main'
  from /usr/lib/crystal/src/crystal/main.cr:0:3 in 'main'
  from /usr/lib/crystal/src/crystal/hasher.cr:105:23 in '__libc_start_main'
```

Added fix and test to validate.